### PR TITLE
Web adapters

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,17 +1,3 @@
 source "https://rubygems.org"
 
-gem 'rake', '~> 11.1', '>= 11.1.2'
-
-group :test do
-  gem 'rspec'
-  gem 'simplecov',                 :require => false
-  gem "codeclimate-test-reporter", :require => false
-  gem 'coveralls',                 :require => false
-  gem 'scrutinizer-ocular',        :require => false
-end
-
-group :docs do
-  gem 'yard',         :git => 'https://github.com/trevorrowe/yard.git', branch: 'frameless'
-  gem 'yard-sitemap', '~> 1.0'
-  gem 'rdiscount'
-end
+gemspec

--- a/README.md
+++ b/README.md
@@ -64,6 +64,27 @@ response = wepay.call('/account/create', access_token, {
 })
 ```
 
+## Configuration
+
+WePay can be configured in a block:
+
+ruby
+```
+WePay.configure do |config|
+  # Switch Faraday web adapter (default Net::HTTP)
+  config.http_adapter = :patron
+end
+```
+
+You can also access the configuration object:
+
+ruby
+```
+config = WePay.configuration
+
+config.http_adapter = :patron
+```
+
 ## Testing
 
 Firstly, run `bundle install` to download and install the dependencies.

--- a/README.md
+++ b/README.md
@@ -74,6 +74,13 @@ You can run the tests as follows:
 make test
 ```
 
+## Console
+
+Start a REPL with the WePay library and dependencies loaded:
+
+```
+bin/console
+```
 
 ## API Reference
 

--- a/bin/console
+++ b/bin/console
@@ -1,0 +1,4 @@
+#!/usr/bin/env ruby
+require 'wepay'
+require 'irb'
+IRB.start

--- a/lib/we_pay/base_request.rb
+++ b/lib/we_pay/base_request.rb
@@ -50,7 +50,8 @@ module WePay
         uri,
         headers: default_headers,
         request: default_request_opts,
-        ssl:     default_ssl_opts
+        ssl:     default_ssl_opts,
+        adapter: http_adapter
       )
     end
 
@@ -81,6 +82,10 @@ module WePay
       { 
         verify: true
       }
+    end
+
+    def http_adapter
+      WePay.configuration.http_adapter
     end
   end
 end

--- a/lib/we_pay/client.rb
+++ b/lib/we_pay/client.rb
@@ -5,9 +5,6 @@
 ##
 
 require 'cgi'
-require 'json'
-require 'net/http'
-require 'net/https'
 
 module WePay
 

--- a/lib/we_pay/client.rb
+++ b/lib/we_pay/client.rb
@@ -1,9 +1,3 @@
-##
-# Copyright (c) 2012-2016 WePay.
-#
-# http://opensource.org/licenses/Apache2.0
-##
-
 require 'cgi'
 
 module WePay

--- a/lib/we_pay/configuration.rb
+++ b/lib/we_pay/configuration.rb
@@ -1,0 +1,19 @@
+require 'singleton'
+
+module WePay
+  class Configuration
+    include ::Singleton
+
+    attr_writer :http_adapter
+
+    def http_adapter
+      @http_adapter || default_http_adapter
+    end
+
+    private
+
+    def default_http_adapter
+      :net_http
+    end
+  end
+end

--- a/lib/wepay.rb
+++ b/lib/wepay.rb
@@ -8,9 +8,17 @@
 # The root WePay namespace.
 ##
 module WePay
-  autoload :Client,      'we_pay/client'
+  autoload :Configuration, 'we_pay/configuration'
 
+  autoload :Client,            'we_pay/client'
   autoload :BaseRequest,       'we_pay/base_request'
   autoload :TestRequest,       'we_pay/test_request'
   autoload :ProductionRequest, 'we_pay/production_request'
+
+  class << self
+
+    def configuration
+      WePay::Configuration.instance
+    end
+  end
 end

--- a/lib/wepay.rb
+++ b/lib/wepay.rb
@@ -17,6 +17,10 @@ module WePay
 
   class << self
 
+    def configure(&block)
+      block.call(configuration)
+    end
+
     def configuration
       WePay::Configuration.instance
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,7 +12,9 @@ SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter[
   SimpleCov::Formatter::HTMLFormatter,
   Coveralls::SimpleCov::Formatter
 ]
-SimpleCov.start
+SimpleCov.start do
+  add_filter "/spec/"
+end
 
 require 'wepay'
 

--- a/spec/we_pay/configuration_spec.rb
+++ b/spec/we_pay/configuration_spec.rb
@@ -1,0 +1,34 @@
+require 'spec_helper'
+
+RSpec.describe WePay::Configuration do
+
+  subject { described_class.instance }
+
+  describe "as a singleton" do
+    it "returns an instance" do
+      expect(described_class.instance).to be_an_instance_of(described_class)
+    end
+  end
+
+  describe "#http_adapter" do
+    context "by default" do
+      it "returns Net Http" do
+        expect(subject.http_adapter).to eq(:net_http)
+      end
+    end
+
+    context "with an explicit adapter" do
+      before do
+        subject.http_adapter = :patron
+      end
+
+      after do
+        subject.http_adapter = nil
+      end
+
+      it "returns the adapter" do
+        expect(subject.http_adapter).to eq(:patron)
+      end
+    end
+  end
+end

--- a/spec/we_pay/production_request_spec.rb
+++ b/spec/we_pay/production_request_spec.rb
@@ -26,6 +26,8 @@ RSpec.describe WePay::ProductionRequest do
       }
     end
 
+    let(:default_http_adapter) { :net_http }
+
     subject do
       described_class.new(
         'client_id',
@@ -42,7 +44,8 @@ RSpec.describe WePay::ProductionRequest do
         URI.parse("https://wepayapi.com/v2/path"),
         headers: header_opts,
         request: request_opts,
-        ssl:     ssl_opts
+        ssl:     ssl_opts,
+        adapter: default_http_adapter
       ).and_return(client)
 
       allow(client).to receive(:post).and_yield(request).and_return(response)

--- a/spec/we_pay/production_request_spec.rb
+++ b/spec/we_pay/production_request_spec.rb
@@ -3,9 +3,28 @@ require 'spec_helper'
 RSpec.describe WePay::ProductionRequest do
 
   describe "#response" do
-    let(:http_response) { double("net::http::response") }
-    let(:http_post)     { double("net::http::post") }
-    let(:http_client)   { double("net::http") }
+    let(:client)   { double("faraday::connection") }
+    let(:request)  { double("faraday::request") }
+    let(:response) { double("faraday::response") }
+
+    let(:header_opts) do
+      {
+        content_type: 'application/json',
+        user_agent:   'WePay Ruby SDK'
+      }
+    end
+
+    let(:request_opts) do
+      {
+        timeout: 30
+      }
+    end
+
+    let(:ssl_opts) do
+      {
+        verify: true
+      }
+    end
 
     subject do
       described_class.new(
@@ -19,31 +38,24 @@ RSpec.describe WePay::ProductionRequest do
     end
 
     before do
-      allow(http_response).to receive(:body).and_return({ response: 'response' }.to_json)
+      allow(Faraday).to receive(:new).with(
+        URI.parse("https://wepayapi.com/v2/path"),
+        headers: header_opts,
+        request: request_opts,
+        ssl:     ssl_opts
+      ).and_return(client)
 
-      allow(Net::HTTP::Post).to receive(:new).with(
-          "/path",
-          'Content-Type' => 'application/json',
-          'User-Agent'   => 'WePay Ruby SDK'
-        ).and_return(http_post)
+      allow(client).to receive(:post).and_yield(request).and_return(response)
 
-      allow(http_post).to receive(:body=).with({ data: 'data' }.to_json)
-      allow(http_post).to receive(:add_field).with('Authorization', "Bearer access_token")
-      allow(http_post).to receive(:add_field).with('Api-Version', "api_version")
+      allow(request).to receive(:url).with("/v2/path")
+      allow(request).to receive(:body=).with({data: 'data'}.to_json)
+      allow(request).to receive(:headers).and_return({})
 
-      allow(Net::HTTP).to receive(:new).with(
-          "wepayapi.com",
-          443
-        ).and_return(http_client)
-
-      allow(http_client).to receive(:read_timeout=).with(30)
-      allow(http_client).to receive(:use_ssl=).with(true)
-      allow(http_client).to receive(:request).with(http_post).and_return(http_response)
-      allow(http_client).to receive(:start).and_yield(http_client)
+      expect(response).to receive(:body).and_return({ status: :ok}.to_json)
     end
 
     it "returns response data" do
-      expect(subject.response).to eq({ 'response' => 'response' })
+      expect(subject.response).to eq('status' => 'ok')
     end
   end
 end

--- a/spec/we_pay/test_request_spec.rb
+++ b/spec/we_pay/test_request_spec.rb
@@ -3,9 +3,30 @@ require 'spec_helper'
 RSpec.describe WePay::TestRequest do
 
   describe "#response" do
-    let(:http_response) { double("net::http::response") }
-    let(:http_post)     { double("net::http::post") }
-    let(:http_client)   { double("net::http") }
+    let(:client)   { double("faraday::connection") }
+    let(:request)  { double("faraday::request") }
+    let(:response) { double("faraday::response") }
+
+    let(:stage_url) { "https://stage.wepayapi.com/v2" }
+
+    let(:header_opts) do
+      {
+        content_type: 'application/json',
+        user_agent:   'WePay Ruby SDK'
+      }
+    end
+
+    let(:request_opts) do
+      {
+        timeout: 30
+      }
+    end
+
+    let(:ssl_opts) do
+      {
+        verify: true
+      }
+    end
 
     subject do
       described_class.new(
@@ -19,31 +40,24 @@ RSpec.describe WePay::TestRequest do
     end
 
     before do
-      allow(http_response).to receive(:body).and_return({ response: 'response' }.to_json)
+      allow(Faraday).to receive(:new).with(
+        URI.parse("https://stage.wepayapi.com/v2/path"),
+        headers: header_opts,
+        request: request_opts,
+        ssl:     ssl_opts
+      ).and_return(client)
 
-      allow(Net::HTTP::Post).to receive(:new).with(
-          "/path",
-          'Content-Type' => 'application/json',
-          'User-Agent'   => 'WePay Ruby SDK'
-        ).and_return(http_post)
+      allow(client).to receive(:post).and_yield(request).and_return(response)
 
-      allow(http_post).to receive(:body=).with({ data: 'data' }.to_json)
-      allow(http_post).to receive(:add_field).with('Authorization', "Bearer access_token")
-      allow(http_post).to receive(:add_field).with('Api-Version', "api_version")
+      allow(request).to receive(:url).with("/v2/path")
+      allow(request).to receive(:body=).with({data: 'data'}.to_json)
+      allow(request).to receive(:headers).and_return({})
 
-      allow(Net::HTTP).to receive(:new).with(
-          "stage.wepayapi.com",
-          443
-        ).and_return(http_client)
-
-      allow(http_client).to receive(:read_timeout=).with(30)
-      allow(http_client).to receive(:use_ssl=).with(true)
-      allow(http_client).to receive(:request).with(http_post).and_return(http_response)
-      allow(http_client).to receive(:start).and_yield(http_client)
+      expect(response).to receive(:body).and_return({ status: :ok}.to_json)
     end
 
     it "returns response data" do
-      expect(subject.response).to eq({ 'response' => 'response' })
+      expect(subject.response).to eq('status' => 'ok')
     end
   end
 end

--- a/spec/we_pay/test_request_spec.rb
+++ b/spec/we_pay/test_request_spec.rb
@@ -28,6 +28,8 @@ RSpec.describe WePay::TestRequest do
       }
     end
 
+    let(:default_http_adapter) { :net_http }
+
     subject do
       described_class.new(
         'client_id',
@@ -44,7 +46,8 @@ RSpec.describe WePay::TestRequest do
         URI.parse("https://stage.wepayapi.com/v2/path"),
         headers: header_opts,
         request: request_opts,
-        ssl:     ssl_opts
+        ssl:     ssl_opts,
+        adapter: default_http_adapter
       ).and_return(client)
 
       allow(client).to receive(:post).and_yield(request).and_return(response)

--- a/spec/we_pay_spec.rb
+++ b/spec/we_pay_spec.rb
@@ -2,6 +2,24 @@ require 'spec_helper'
 
 RSpec.describe WePay do
 
+  describe ".configure" do
+    before do
+      WePay.configuration.http_adapter = :net_http
+    end
+
+    after do
+      WePay.configuration.http_adapter = :net_http
+    end
+
+    it "yields the configuration to the block" do
+      described_class.configure do |config|
+        config.http_adapter = :patron
+      end
+
+      expect(described_class.configuration.http_adapter).to eq(:patron)
+    end
+  end
+
   describe ".configuration" do
     it "returns the WePay configuration" do
       expect(described_class.configuration).to be_an_instance_of(WePay::Configuration)

--- a/spec/we_pay_spec.rb
+++ b/spec/we_pay_spec.rb
@@ -1,0 +1,10 @@
+require 'spec_helper'
+
+RSpec.describe WePay do
+
+  describe ".configuration" do
+    it "returns the WePay configuration" do
+      expect(described_class.configuration).to be_an_instance_of(WePay::Configuration)
+    end
+  end
+end

--- a/wepay.gemspec
+++ b/wepay.gemspec
@@ -1,14 +1,30 @@
 Gem::Specification.new do |s|
-  s.name        = 'wepay'
-  s.version     = '0.3.0'
-  s.date        = '2016-06-11'
+  s.name        = "wepay"
+  s.version     = "0.3.0"
+  s.authors     = ["WePay"]
+  s.email       = "api@wepay.com"
+  s.date        = "2016-06-11"
 
   s.summary     = "WePay SDK for Ruby"
   s.description = "The WePay SDK for Ruby lets you easily make WePay API calls from Ruby."
-  s.authors     = ["WePay"]
-  s.email       = 'api@wepay.com'
-  s.homepage    = 'https://github.com/wepay/Ruby-SDK'
-  s.license     = 'Apache-2.0'
+  s.homepage    = "https://github.com/wepay/Ruby-SDK"
+  s.license     = "Apache-2.0"
 
   s.files       = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
+  s.test_files  = Dir["spec/**/*"]
+
+  s.add_dependency "faraday", ">= 0.9.0"
+
+  s.add_development_dependency "bundler", "~> 1.12"
+  s.add_development_dependency "rake",    "~> 10.0"
+  s.add_development_dependency "rspec",   "~> 3.0"
+
+  s.add_development_dependency "simplecov"
+  s.add_development_dependency "codeclimate-test-reporter"
+  s.add_development_dependency "coveralls"
+  s.add_development_dependency "scrutinizer-ocular"
+
+  s.add_development_dependency "yard"
+  s.add_development_dependency "yard-sitemap"
+  s.add_development_dependency "rdiscount"
 end


### PR DESCRIPTION
Replace `Net::HTTP` with `Faraday`, use `Net::HTTP` as the default faraday web adapter.

Add `WePay::Configuration`, web adapter configuration.

Add `bin/console` for playing with the client, debugging.

Update README to reflect new changes.
